### PR TITLE
Fix xUnit warnings.

### DIFF
--- a/UnitTest/AlgorithmsTests/SieveOfEratosthenesTests.cs
+++ b/UnitTest/AlgorithmsTests/SieveOfEratosthenesTests.cs
@@ -14,7 +14,7 @@ namespace UnitTest.AlgorithmsTests
             var results = SieveOfEratosthenes.GeneratePrimesUpTo(MaxNumber);
             Assert.NotNull(results);
             Assert.True(results.Any());
-            Assert.Equal(results.Count(), 25);
+            Assert.Equal(25, results.Count());
             Assert.DoesNotContain(1, results);
             Assert.Contains(2, results);
             Assert.Contains(7, results);

--- a/UnitTest/DataStructuresTests/BTreeTest.cs
+++ b/UnitTest/DataStructuresTests/BTreeTest.cs
@@ -171,7 +171,7 @@ namespace UnitTest.DataStructuresTests
              */
 
             // The tree should now be rooted around 40, with the left child full.
-            Assert.Equal(null, bTree.Search(5));
+            Assert.Null(bTree.Search(5));
             Assert.Equal(2, bTree.Root.Children.Count);
             Assert.Equal(7, bTree.Root.Children[0].Keys.Count); // left-most
             Assert.Equal(3, bTree.Root.Children[1].Keys.Count); // right-most

--- a/UnitTest/DataStructuresTests/CircularBufferTest.cs
+++ b/UnitTest/DataStructuresTests/CircularBufferTest.cs
@@ -140,14 +140,16 @@ namespace UnitTest.DataStructuresTests
         }
 
         [Fact]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Assertions", "xUnit2017:Do not use Contains() to check if a value exists in a collection", Justification = "This tests the Contains method")]
         public static void TestingICollectionImplementation() 
         {
             var circularBuffer = new CircularBuffer<byte>(3, false);
             circularBuffer.Add(3);
             circularBuffer.Add(34);
             circularBuffer.Add(24);
-            //Testing contains
+            //Testing Contains
             Assert.True(circularBuffer.Contains(3));
+            Assert.Contains<byte>(3, circularBuffer);
             
             //Testing CopyTo
             var array = new byte[3];


### PR DESCRIPTION
### Description
Fix (or ignore) compilation warnings in tests
Closes #4.

### Checklist

- [x] An issue was first created **before** opening this pull request
- [x] The new code follows the [contribution guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (N/A) I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings
- [x] (N/A) I have added tests to ensure that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

