### PR TITLE
Fix NullReferenceException in SLinkedListEnumerator.MoveNext().

### DIFF
--- a/DataStructures/Lists/SLinkedList.cs
+++ b/DataStructures/Lists/SLinkedList.cs
@@ -461,11 +461,11 @@ namespace DataStructures.Lists
         internal class SLinkedListEnumerator : IEnumerator<T>
         {
             private SLinkedListNode<T> _current;
-            private SLinkedList<T> _doublyLinkedList;
+            private SLinkedList<T> _list;
 
             public SLinkedListEnumerator(SLinkedList<T> list)
             {
-                this._doublyLinkedList = list;
+                this._list = list;
                 this._current = list.Head;
             }
 
@@ -481,20 +481,22 @@ namespace DataStructures.Lists
 
             public bool MoveNext()
             {
-                _current = _current.Next;
-
-                return (this._current != null);
+                if (_current != null)
+                {
+                    _current = _current.Next;
+                }
+                return (_current != null);
             }
 
             public void Reset()
             {
-                _current = _doublyLinkedList.Head;
+                _current = _list.Head;
             }
 
             public void Dispose()
             {
                 _current = null;
-                _doublyLinkedList = null;
+                _list = null;
             }
         }
     }

--- a/UnitTest/DataStructuresTests/SLinkedListTest.cs
+++ b/UnitTest/DataStructuresTests/SLinkedListTest.cs
@@ -1,4 +1,5 @@
 ﻿using DataStructures.Lists;
+using System.Collections.Generic;
 using Xunit;
 
 namespace UnitTest.DataStructuresTests
@@ -60,6 +61,13 @@ namespace UnitTest.DataStructuresTests
 
             Assert.True(intArray[0] == 0 && intArray[intArray.Length - 1] == 55, "Wrong sorting!");
         }
+
+        [Fact]
+        public static void EnumerateEmptyList()
+        {
+            SLinkedList<int> emptyList = new SLinkedList<int>();
+            IEnumerator<int> enumerator = emptyList.GetEnumerator();
+            Assert.False(enumerator.MoveNext());
+        }
     }
 }
-


### PR DESCRIPTION
### Description

Fix NullReferenceException in SLinkedListEnumerator.MoveNext().
Closes #6.

### Checklist

- [x] An issue was first created **before** opening this pull request
- [x] The new code follows the [contribution guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (although it's hard to tell with so many warnings in the code)
- [x] I have added tests to ensure that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

